### PR TITLE
Update extract_gapps_pico.sh

### DIFF
--- a/extract_gapps_pico.sh
+++ b/extract_gapps_pico.sh
@@ -12,6 +12,6 @@ echo "Unzipping OpenGApps"
 find "$GAppsRoot/"*.zip -exec unzip -p {} {Core,GApps}/'*.lz' \; | tar --lzip -C $GAppsOutputFolder -xvf - -i --strip-components=2 --exclude='setupwizardtablet-x86_64'
 
 echo "Post merge operation"
-cp -ra $GAppsOutputFolder/product/* $GAppsRoot/product_output/
+cp -ra $GAppsOutputFolder/* $GAppsRoot/product_output/
 
 echo "!! GApps folder ready !!"


### PR DESCRIPTION
There is no folder named "product" that exists inside the GAppsOutputFolder. When merging files from #GAPPS/output/product to /product_output displays an error on the terminal because all the extracted data is inside the "output/" not inside the "output/product" directory.